### PR TITLE
Simplify handling of tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ RenovateVersion      | renovate version to use                        | latest|
 RenovateFlags        | see `--help` for details about supported flags   ||
 RenovatePlatform     | the platform, requires `GitHubToken` or `GitLabToken` ||
 RenovateSchedule     | schedule the renovate [ScheduleExpressions] |`cron(45 23 ? * 1-5 *)`|
-GitHubToken          | token used when platform is `github`          | NOT_SET|
-GitLabToken          | token used when platform is `gitlab`          | NOT_SET|
+RenovatePlatformToken| token for the platform (`github` or `gitlab`)         ||
 |||
 TimeoutInMinutes     | timeout for renovate build                    | `10`   |
 ComputerType| computer to to use with `renovate`| `BUILD_GENERAL1_SMALL`       |

--- a/cloudformation/renovate.yml
+++ b/cloudformation/renovate.yml
@@ -112,7 +112,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - codebuild:StartBuild
-                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/Renovate-*"
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:project/Renovate-*"
 
   RenovateCronRule:
     Type: AWS::Events::Rule

--- a/cloudformation/renovate.yml
+++ b/cloudformation/renovate.yml
@@ -30,6 +30,11 @@ Parameters:
       - github
       - gitlab
 
+  RenovatePlatformToken:
+    Type: String
+    MinLength: 1
+    NoEcho: true
+
   Image:
     Type: String
     Default: aws/codebuild/nodejs:10.1.0
@@ -42,36 +47,23 @@ Parameters:
     Type: Number
     Default: 10
 
-  GitHubToken:
-    Type: String
-    Default: NOT_SET
-    MinLength: 1
-    NoEcho: true
-
-  GitLabToken:
-    Description: |
-    Type: String
-    Default: NOT_SET
-    MinLength: 1
-    NoEcho: true
-
 Conditions:
   HasRenovateSchedule: {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "RenovateSchedule"}]}]}
 
-Resources:
-  RenovateGitHubToken:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: /renovate-aws/GITHUB_TOKEN
-      Value: !Ref GitHubToken
+Mappings:
+  PlatformToEnv:
+    gitlab:
+      Value: "    GITLAB_TOKEN"
+    github:
+      Value: "    GITHUB_TOKEN"
 
-  RenovateGitLabToken:
+Resources:
+  RenovatePlatformTokenParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: /renovate-aws/GITLAB_TOKEN
-      Value: !Ref GitLabToken
+      Name: /renovate-aws/platform_token
+      Value: !Ref RenovatePlatformToken
 
   RenovateRole:
     Type: AWS::IAM::Role
@@ -155,25 +147,33 @@ Resources:
             Value: !Ref RenovatePlatform
       Source:
         Type: NO_SOURCE
-        BuildSpec: |
-          version: 0.2
-          env:
-            variables:
-              CI: "1"
-            parameter-store:
-              GITHUB_TOKEN: /renovate-aws/GITHUB_TOKEN
-              GITLAB_TOKEN: /renovate-aws/GITLAB_TOKEN
-          phases:
-            install:
-              commands:
-                - npm install renovate@${RENOVATE_VERSION}
-                - "$(npm bin)/renovate --version"
-            build:
-              commands:
-                - $(npm bin)/renovate ${RENOVATE_FLAGS}
-          cache:
-            paths:
-              - "node_modules/**/*"
+        BuildSpec: !Join
+          - ""
+          -
+            - |
+                version: 0.2
+                env:
+                  variables:
+                    CI: "1"
+                  parameter-store:
+            - !Join
+              - ""
+              -
+                - !Join
+                  - ": "
+                  -
+                    - !FindInMap [ PlatformToEnv, !Ref "RenovatePlatform", Value ]
+                    - /renovate-aws/platform_token
+                - "\n"
+            - |
+                phases:
+                  install:
+                    commands:
+                      - npm install renovate@${RENOVATE_VERSION}
+                      - "$(npm bin)/renovate --version"
+                  build:
+                    commands:
+                      - $(npm bin)/renovate ${RENOVATE_FLAGS}
       TimeoutInMinutes: !Ref TimeoutInMinutes
 
 Outputs:


### PR DESCRIPTION
Replace `GitHubToken` and `GitLabToken` with `RenovatePlatformToken`

Let the template handle the use of the token, either by using as
`GITHUB_TOKEN` or `GITLAB_TOKEN` environment variable

The value of RenovatePlatformToken will be stores in SSM with
parameter name `/renovate-aws/platform_token`

Fix `Resource` for the policy created by `RenovateCronRuleRole`
as it did not allow the `RenovateCronRule` to start build

Fixes: https://github.com/frodeaa/renovate-aws/issues/6